### PR TITLE
remove bad formatting for icon_emoji in slackr()

### DIFF
--- a/R/slackr.R
+++ b/R/slackr.R
@@ -35,8 +35,6 @@ slackr <- function(...,
     stop("No token specified. Did you forget to call slackr_setup()?", call. = FALSE)
   }
 
-  if (icon_emoji != "") { icon_emoji <- sprintf(', "icon_emoji": "%s"', icon_emoji)  }
-
   resp_ret <- ""
 
   if (!missing(...)) {


### PR DESCRIPTION
Thanks for the excellent r package!  the slackr() function using the api_token doesn’t need extra formatting to set the icon_emoji, and will just use the default slack icon if the formatted string is passed as it was coded.
